### PR TITLE
chore: remove obsolete data fetch error message

### DIFF
--- a/src/components/WhiteListMember.vue
+++ b/src/components/WhiteListMember.vue
@@ -339,7 +339,6 @@ const getWhiteList = (showMessage = false) => {
       })
       .catch((error) => {
         console.error('获取数据失败：', error);
-        ElMessage.error('获取数据时发生错误，请检查网络或联系管理员');
       })
       .finally(() => {
         loading.value = false;


### PR DESCRIPTION
## Summary
- remove outdated fetch error message from whitelist member view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ae0b1274c8330853a940e35d337b2