### PR TITLE
chore: adjust member button spacing

### DIFF
--- a/src/components/WhiteListApplication.vue
+++ b/src/components/WhiteListApplication.vue
@@ -433,7 +433,7 @@ const handleFormBlur = () => {
 /* 修改查看成员按钮样式 */
 .view-members-btn {
   position: absolute;
-  right: 20px;
+  right: 10px;
   top: 50%;
   transform: translateY(-50%);
   display: flex;


### PR DESCRIPTION
## Summary
- shift "view members" button slightly right for better alignment

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ae1fa33d48330b2d630ae1d79db7d